### PR TITLE
Allow Openssl to build on arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ elseif(UNIX)
   list(APPEND OPENSSL_DEFS
     -DOPENSSL_USE_NODELETE
     )
-  set(asmDir asmfromnode/archs/linux-x86_64/asm)
+  set(asmDir asmfromnode/archs/linux-${CMAKE_SYSTEM_PROCESSOR}/asm)
 endif()
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64") AND WIN32)
   enable_language(ASM_NASM) # -DCMAKE_ASM_NASM_COMPILER=/path/to/nasm.exe

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -1859,6 +1859,7 @@ add_library(${lib_name} STATIC ${${lib_name}_libsrcs})
 target_include_directories(${lib_name} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_BINARY_DIR}/include # buildinf.h, internal/[bn|dso]_conf.h
+  ${CMAKE_CURRENT_SOURCE_DIR} # arm_arch.h
   ec/curve448
   ec/curve448/arch_32
   modes # evp includes modes_lcl.h


### PR DESCRIPTION
Add arm.h into include path for aarch64
Use architecture type to determine if the assembly code is there
Here is the pull to externpro: https://github.com/smanders/externpro/pull/309