### PR TITLE
dirtyrepo

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -7,24 +7,24 @@ on:
   workflow_dispatch:
 jobs:
   linux:
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     with:
       cmake-workflow-preset: Linux
       runon: ubuntu-latest
     secrets: inherit
   linux-arm64:
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.06
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     with:
       cmake-workflow-preset: Linux
       runon: ubuntu-24.04-arm
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.06
+    uses: externpro/externpro/.github/workflows/build-macos.yml@main
     with:
       cmake-workflow-preset: Darwin
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.06
+    uses: externpro/externpro/.github/workflows/build-windows.yml@main
     with:
       cmake-workflow-preset: Windows
     secrets: inherit


### PR DESCRIPTION
determining why `1.1.1l.1` release has a dirty repo on Windows
https://github.com/externpro/openssl/releases/tag/v1.1.1l.1
[openssl-v1.1.1l.1-dr-win64-devel.tar.xz](https://github.com/externpro/openssl/releases/download/v1.1.1l.1/openssl-v1.1.1l.1-dr-win64-devel.tar.xz)